### PR TITLE
cache settings

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -7,6 +7,27 @@
   },
   "hosting": {
     "public": "build",
+    "headers": [
+      {
+        "source": "/**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, no-store, must-revalidate"
+          }
+        ]
+      },
+      { 
+        "source":
+          "**/*.@(jpg|jpeg|gif|png|svg|js|css|eot|otf|ttf|ttc|woff|font.css)",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "max-age=604800"
+          }
+        ]
+      }
+    ],
     "ignore": [
       "firebase.json",
       "**/.*",

--- a/firebase.json
+++ b/firebase.json
@@ -23,7 +23,7 @@
         "headers": [
           {
             "key": "Cache-Control",
-            "value": "max-age=604800"
+            "value": "max-age=7200"
           }
         ]
       }

--- a/firebase.json
+++ b/firebase.json
@@ -19,7 +19,7 @@
       },
       { 
         "source":
-          "**/*.@(jpg|jpeg|gif|png|svg|js|css|eot|otf|ttf|ttc|woff|font.css)",
+          "**/*.@(jpg|jpeg|gif|png|svg|eot|otf|ttf|ttc|woff)",
         "headers": [
           {
             "key": "Cache-Control",


### PR DESCRIPTION
The logic is to use cache for all static files like images etc.. For all others, i.ie `"source": "/**"` set cache as no-cache.